### PR TITLE
optimization -> lexer from O(n²) to O(n) character access possible fix

### DIFF
--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -2,7 +2,6 @@ use crate::lexer::{Token, TokenType};
 
 pub struct Lexer {
     source: Vec<char>,
-    source_string: String,
     tokens: Vec<Token>,
     start: usize,
     current: usize,
@@ -14,7 +13,6 @@ impl Lexer {
         let chars: Vec<char> = source.chars().collect();
         Lexer {
             source: chars,
-            source_string: source,
             tokens: vec![],
             start: 0,
             current: 0,

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -1,7 +1,8 @@
 use crate::lexer::{Token, TokenType};
 
 pub struct Lexer {
-    source: String,
+    source: Vec<char>,
+    source_string: String,
     tokens: Vec<Token>,
     start: usize,
     current: usize,
@@ -10,8 +11,10 @@ pub struct Lexer {
 
 impl Lexer {
     pub fn new(source: String) -> Self {
+        let chars: Vec<char> = source.chars().collect();
         Lexer {
-            source,
+            source: chars,
+            source_string: source,
             tokens: vec![],
             start: 0,
             current: 0,
@@ -95,7 +98,7 @@ impl Lexer {
             return '\0';
         }
 
-        self.source.chars().nth(self.current).unwrap()
+        self.source[self.current]
     }
 
     pub fn scan_tokens(&mut self) -> Vec<Token> {
@@ -124,21 +127,23 @@ impl Lexer {
     }
 
     fn add_token(&mut self, token_type: TokenType) {
-        let mut text = String::from(&self.source[self.start..self.current]);
+        let text: String = self.source[self.start..self.current].iter().collect();
 
-        if token_type == TokenType::Whitespace {
-            text = " ".to_owned();
-        }
+        let final_text = if token_type == TokenType::Whitespace {
+            " ".to_owned()
+        } else {
+            text
+        };
 
         self.tokens
-            .push(Token::new(token_type, text, self.line, self.start));
+            .push(Token::new(token_type, final_text, self.line, self.start));
     }
 
     fn matching(&mut self, expected: char) -> bool {
         if self.is_at_end() {
             return false;
         }
-        if self.source.chars().nth(self.current).unwrap() != expected {
+        if self.source[self.current] != expected {
             return false;
         }
 


### PR DESCRIPTION
peak() was using self.source.chars().nth(self.current) to get chars, which iterates from the start of the string every time so rust strings are UTF-8 encoded -> every character lookup O(n) instead of O(1) and scanning for file became O(n²) overall. 
fixed -> converting the source string to a Vec<char> when the lexer is created. 
Now we can just do self.source[self.current] for direct O(1) access.\